### PR TITLE
Fix job deletion and restart functionality on paginated pages

### DIFF
--- a/web/media/main_script.js
+++ b/web/media/main_script.js
@@ -68,8 +68,8 @@ $(document).ready(function()
         });
     });
 
-    // Delete job user click
-    $("button[type = 'delete_job']").on("click", function (event)
+    // Delete job user click - using event delegation to work with DataTables pagination
+    $(document).on("click", "button[type = 'delete_job']", function (event)
     {
         // Get the job ID
         var job_id              = $(this).attr('job_id');
@@ -86,8 +86,8 @@ $(document).ready(function()
         // And off we go...
     });
 
-    // Restart job user click
-    $("form[type = 'form_restart_job'").on('submit', function (event)
+    // Restart job user click - using event delegation to work with DataTables pagination
+    $(document).on('submit', "form[type = 'form_restart_job']", function (event)
     {
         event.preventDefault();
         // Let's get the children select


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are making a pull request against the **devel branch** (left side). Also you should start *your branch* off *our devel*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Description
Fixes issue https://github.com/KasperskyLab/klara/issues/11, where job deletion and restart functionality only worked on the first page of the job management interface when pagination was active.

#### Problem
When the job list contained more than 10 jobs (triggering DataTables pagination), the delete and restart buttons on pages 2, 3, etc. were non-functional due to improper JavaScript event binding.

#### Root Cause
The JavaScript code used direct event binding, which only attached handlers to DOM elements present at page load. DataTables pagination dynamically shows/hides content, so buttons on subsequent pages never receive event handlers.

#### Solution
- Changed direct event binding to event delegation for both delete and restart functionality
- Used `$(document).on()` instead of `$("selector").on()` to ensure handlers work with dynamically paginated content

Closes #11